### PR TITLE
Kein Hostname Präfix

### DIFF
--- a/site.conf
+++ b/site.conf
@@ -1,5 +1,5 @@
 {
-	hostname_prefix = 'ffhb',
+	hostname_prefix = '',
 	site_name = 'Freifunk Bremen',
 	site_code = 'ffhb',
 


### PR DESCRIPTION
Es wurde der wunsch geäußert, das der Präfix abgeschaft werden soll.
Dadurch werden unbekannt dazu geleitet, den ganzen Namen zu ändern (und nicht das ffhb stehen zu lassen).
