### PR TITLE
Build-Dependencies realpath und libssl-dev hinzugefügt

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Um die Bremer Firmware zu bauen sind folgende Vorbereitungen notwendig:
 ```sh
 # Build-Dependencies installieren (Debian)
-sudo apt-get install coreutils build-essential subversion git libncurses5-dev zlib1g-dev unzip gawk
+sudo apt-get install coreutils build-essential subversion git libncurses5-dev zlib1g-dev unzip gawk realpath libssl-dev
 # Dieses und das Gluon-Repository clonen
 git clone --recursive https://github.com/FreifunkBremen/gluon-site-ffhb.git
 ```


### PR DESCRIPTION
Ich brauchte die beiden Pakete um Gluon unter Ubuntu 14.04 zu bauen. Daher gehe ich stark davon aus das man sie unter Debian auch braucht.
