### PR TITLE
Added trailing slash to ec8ors mirror urls

### DIFF
--- a/site.conf
+++ b/site.conf
@@ -94,7 +94,7 @@
 					'http://downloads.bremen.freifunk.net/firmware/testing/sysupgrade',
 					'http://[2001:bf7:540::c8]/testing/sysupgrade', -- jplitza
 					'http://[2a03:b0c0:3:d0::19:4001]/ffhb-mirror/firmware/testing/sysupgrade', -- janeric
-					'http://[2001:bf7:540::6f]/ffhb-mirror/testing/sysupgrade', -- ec8or
+					'http://[2001:bf7:540::6f]/ffhb-mirror/testing/sysupgrade/', -- ec8or
 					'http://[2001:bf7:540::82]/firmware/testing/sysupgrade', -- mortzu
 				},
 				good_signatures = 1,
@@ -115,7 +115,7 @@
 					'http://downloads.bremen.freifunk.net/firmware/stable/sysupgrade',
 					'http://[2001:bf7:540::c8]/stable/sysupgrade', -- jplitza
 					'http://[2a03:b0c0:3:d0::19:4001]/ffhb-mirror/firmware/stable/sysupgrade', -- janeric
-					'http://[2001:bf7:540::6f]/ffhb-mirror/stable/sysupgrade', -- ec8or
+					'http://[2001:bf7:540::6f]/ffhb-mirror/stable/sysupgrade/', -- ec8or
 					'http://[2001:bf7:540::82]/firmware/stable/sysupgrade', -- mortzu
 				},
 				good_signatures = 2,


### PR DESCRIPTION
Moin,

heute beim Treffen hat jemand die Mirrorlinks getestet und u.a. folgenden Link aufgerufen: `http://[2001:bf7:540::6f]/ffhb-mirror/testing/sysupgrade`

Darauf hin wurde er auf `blackbox.com` umgeleitet. Der Webserver Antwortete hier mit einem HTTP 302 mit der Location "blackbox:80". Ich denke das .com hat Firefox angehängt, als "Autovervollständigung".

Auf folgender Aufruf liefert die richtige Seite zurück:
`wget -6 http://\[2001:bf7:540::6f\]/ffhb-mirror/testing/sysupgrade/`

Folgender nicht:
`wget -6 http://\[2001:bf7:540::6f\]/ffhb-mirror/testing/sysupgrade`

Der Unterschied: Ein abschließender Slash.

Wie es aussieht, mag webfs das nicht anders, deshalb ha ich in den in der site.conf ergänzt.
