### PR TITLE
Updated IP address of my mirror server

### DIFF
--- a/site.conf
+++ b/site.conf
@@ -94,7 +94,7 @@
 					'http://downloads.bremen.freifunk.net/firmware/testing/sysupgrade',
 					'http://[2001:bf7:540::c8]/testing/sysupgrade', -- jplitza
 					'http://[2a03:b0c0:3:d0::19:4001]/ffhb-mirror/firmware/testing/sysupgrade', -- janeric
-					'http://[2001:bf7:540::6f]/ffhb-mirror/testing/sysupgrade', -- ec8or
+					'http://[2a06:8782:ffbb:1337::6f]/ffhb-mirror/testing/sysupgrade', -- ec8or
 				},
 				good_signatures = 1,
 				pubkeys = {
@@ -113,7 +113,7 @@
 					'http://downloads.bremen.freifunk.net/firmware/stable/sysupgrade',
 					'http://[2001:bf7:540::c8]/stable/sysupgrade', -- jplitza
 					'http://[2a03:b0c0:3:d0::19:4001]/ffhb-mirror/firmware/stable/sysupgrade', -- janeric
-					'http://[2001:bf7:540::6f]/ffhb-mirror/stable/sysupgrade', -- ec8or
+					'http://[2a06:8782:ffbb:1337::6f]/ffhb-mirror/stable/sysupgrade', -- ec8or
 				},
 				good_signatures = 2,
 				pubkeys = {


### PR DESCRIPTION
PI ist gakputt gegangen. Nach Reparatur gleich auf neues Prefix(`2a06:8782:ffbb:1337`) aktualisiert. 
