### PR TITLE
build.sh: use correct manifest path for signing

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -158,7 +158,7 @@ make manifest
 cd ..
 
 if [ -n "$KEYFILE" -a -r "$KEYFILE" ]; then
-  "${GLUON_DIR}/contrib/sign.sh" "$KEYFILE" "${GLUON_DIR}/images/sysupgrade/${GLUON_BRANCH}.manifest"
+  "${GLUON_DIR}/contrib/sign.sh" "$KEYFILE" "${GLUON_DIR}/output/images/sysupgrade/${GLUON_BRANCH}.manifest"
 fi
 
 rm "$statefile"


### PR DESCRIPTION
Looks like this was changed in Gluon 2016.1 .
