### PR TITLE
Rewrite build.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,23 +2,32 @@
 
 Um die Bremer Firmware zu bauen sind folgende Vorbereitungen notwendig:
 ```sh
-# Build-Dependencies installieren (Debian)
-sudo apt-get install coreutils build-essential subversion git libncurses5-dev zlib1g-dev unzip gawk libssl-dev
+# Build-Dependencies installieren (Debian/Ubuntu)
+sudo apt-get install coreutils schedtool build-essential subversion git libncurses5-dev zlib1g-dev unzip gawk libssl-dev
 # Dieses und das Gluon-Repository clonen
 git clone --recursive https://github.com/FreifunkBremen/gluon-site-ffhb.git
 ```
 
-Um eine neue Testing-Version der Bremer Firmware zu bauen sind folgende Befehle nötig:
+Um eine bestimmte Version der Bremer Firmware zu bauen sind folgende Befehle nötig:
 ```sh
 # In das Verzeichnis wechseln
 cd gluon-site-ffhb/
-# Gluon auf die gewünschte Version bringen ($tag ist z.B. v2015.1.1)
-git -C gluon checkout $tag
+# Die gewünschte Version auschecken ($tag ist z.B. v2016.2.3+bremen2)
+git checkout $tag
+# Gluon auf die passende Version bringen
+git submodule update
 # Build-Prozess anstoßen
-./build.sh testing
+./build.sh
 ```
-Das Script `build.sh` versucht die richtige Versionsnummer automatisch aus dem gewählten Gluon-Tag und der letzten veröffentlichten Testing-Version zu bestimmen, sie kann aber auch manuell eingegeben werden. Will man stattdessen eine Stable bauen, ändert man einfach nur das `testing` in der letzten Zeile zu `stable`.
+Lief der Build-Prozess erfolgreich durch, liegen in `gluon/output/images/` die fertigen Images inklusive eines Manifests für den Autoupdater, das schon mit dem eigenen ECDSA-Key signiert wurde falls dieser unter `~/.ecdsakey` liegt. In `gluon/output/modules/` liegen außerdem per `opkg` auf dem Knoten nachinstallierbare Kernel-Module.
 
-Lief der Build-Prozess erfolgreich durch, liegen in `gluon/images/` die fertigen Images inklusive eines Manifests für den Autoupdater, das schon mit dem eigenen ECDSA-Key signiert wurde falls dieser unter `~/.ecdsakey` liegt.
+Will man ohne `build.sh` manuell `make` im Verzeichnis gluon aufrufen, wie in der [offiziellen Gluon-Doku](https://gluon.readthedocs.org/en/stable/user/getting_started.html#building-the-images), muss man *jedem* Aufruf von `make` den Parameter `GLUON_SITEDIR=$PWD/../` nachstellen (oder wie in `build.sh` einmal per `export GLUON_SITEDIR=$PWD/../` setzen), damit Gluon das site-Repository findet. Alternativ kann man einen Symlink anlegen, indem man während man im site-Repository ist den Befehl `ln -s $PWD gluon/site` ausführt.
 
-Will man ohne `build.sh` manuell `make` im Verzeichnis gluon aufrufen, wie in der [offiziellen Gluon-Doku](https://gluon.readthedocs.org/en/v2015.1.1/user/getting_started.html#building-the-images), muss man *jedem* Aufruf von `make` den Parameter `GLUON_SITEDIR=$PWD/../` nachstellen (oder wie in `build.sh` einmal per `export GLUON_SITEDIR=$PWD/../` setzen).
+In jedem Fall wird der Gluon-Release-Name automatisch aus dem ausgecheckten Tag generiert - auch falls kein Tag, sondern z.B. der master-Branch ausgecheckt wurde! Falls das nicht gewünscht ist lässt sich durch folgenden Aufruf *vor* dem entsprechenden Build-Befehl (`./build.sh` oder `make`) ein eigener Release-Name festlegen:
+```
+export GLUON_RELEASE="v2016.2.3+bremen3+my_cool_extension"
+```
+Analog lassen sich alle anderen `GLUON_*`-Variablen überschreiben, außerdem die folgenden `build.sh`-spezifischen Variablen:
+
+* `GLUON_TARGETS`: Welche Architekturen werden von `build.sh` gebaut
+* `KEYFILE`: Der Ort des Schlüssels, mit dem das testing/nightly-Manifest automatisch unterschrieben werden soll

--- a/build.sh
+++ b/build.sh
@@ -1,153 +1,45 @@
 #! /usr/bin/env sh
 
-FIRMWARE_URL="http://downloads.bremen.freifunk.net/firmware/"
-LOCAL_SUFFIX="bremen"
-GLUON_DIR="gluon/"
-KEYFILE="$HOME/.ecdsakey"
+# environmental and build settings
+KEYFILE="${KEYFILE:-"$HOME/.ecdsakey"}"
+GLUON_TARGETS="${GLUON_TARGETS:-"ar71xx-generic ar71xx-nand mpc85xx-generic x86-generic"}"
+GLUON_PRIORITY="${GLUON_PRIORITY:-7}"
 
+# start of script
 set -eu
 
+# determine absolute path of site repository
 if which realpath > /dev/null; then
-  GLUON_SITEDIR="$(dirname "$(realpath "$0")")"
+    export GLUON_SITEDIR="$(dirname "$(realpath "$0")")"
 else
-  GLUON_SITEDIR="$(dirname "$(readlink -f "$0")")"
+    export GLUON_SITEDIR="$(dirname "$(readlink -f "$0")")"
 fi
-export GLUON_SITEDIR
+GLUON_DIR="${GLUON_SITEDIR}/gluon/"
 
-get_GLUON_TAG() {
-  if ! git --git-dir="${GLUON_DIR}/.git" describe --exact-match; then
-    echo 'The gluon tree is not checked out at a tag.'
-    echo 'Please use `git checkout <tagname>` to use an official gluon release'
-    echo 'or build it manually. Only with at a tag we can autogenerate the'
-    echo 'release string!'
-    exit 1
-  fi
-}
+# start building
+cd "${GLUON_DIR}"
+make update V=s
 
-get_last_release() {
-  branch="$1"
-  wget -q -O- "${FIRMWARE_URL}/${branch}/sysupgrade/${branch}.manifest" | \
-    awk 'parse == 1 { print $2; exit } /^$/ { parse=1 }'
-}
-
-is_based_on() {
-  [ "${1#$2}" != "${1}" ]
-  return $?
-}
-
-extract_local_version() {
-  local_version_tmp="${1#*+${LOCAL_SUFFIX}}"
-  echo "${local_version_tmp%~testing}"
-}
-
-debug=
-if [ "$#" -gt 0 ]; then
-  if [ "$1" = '-h' -o "$1" = '--help' ]; then
-    cat <<USAGE
-Usage: $(basename $0) [--debug]
-
-This script tries to autodetermine the correct release name, builds gluon for
-all supported platforms (excluding x86*), and optionally signs it if an
-ecdsutils keyfile is found (standard path: ~/.ecdsakey)
-USAGE
-    exit 1
-  fi
-
-  if [ "$1" = "--debug" ]; then
-      debug=1
-      shift
-  fi
-fi
-
-GLUON_BRANCH="stable"
-GLUON_TAG="$(get_GLUON_TAG)"
-# remove prefixed "v"
-GLUON_TAG="${GLUON_TAG#v}"
-
-statefile="${GLUON_SITEDIR}/.build.${GLUON_BRANCH}.${GLUON_TAG}"
-cont=false
-
-if [ -f "$statefile" ]; then
-  echo "A previous build for this version was aborted."
-  echo "These were the parameters:"
-  cat "$statefile"
-  echo "You can now either continue the previous build or begin a new one"
-  echo "and overwrite the old state file."
-  read -p "Do you want to continue the previous build? [Yn] " answer
-  case "${answer:-y}" in
-    [yY]*)
-      . "$statefile"
-      cont=true
-      ;;
-    *)
-      rm "$statefile"
-      ;;
-  esac
-fi
-if ! $cont; then
-  echo "Building Gluon ${GLUON_TAG} as ${GLUON_BRANCH}"
-  last_release_testing="$(get_last_release testing)"
-  last_release_stable="$(get_last_release stable)"
-  last_release="$(echo "${last_release_testing}\n${last_release_stable}" | sort -V | tail -n1)"
-  echo "Last release was ${last_release}"
-  if is_based_on "$last_release" "$GLUON_TAG"; then
-    local_version="$(extract_local_version "$last_release")"
-    local_version="$(($local_version + 1))"
-  else
-    # new gluon version => reset local version number
-    local_version=1
-  fi
-  auto_determined_release="${GLUON_TAG}+${LOCAL_SUFFIX}${local_version}"
-  read -p "Release name for this build [default: ${auto_determined_release}]: " GLUON_RELEASE
-  GLUON_RELEASE="${GLUON_RELEASE:-$auto_determined_release}"
-
-  cat > "$statefile" <<EOF
-GLUON_TAG="${GLUON_TAG}"
-GLUON_BRANCH="${GLUON_BRANCH}"
-GLUON_RELEASE="${GLUON_RELEASE}"
-EOF
-fi
-
-if [ "$GLUON_BRANCH" = "stable" ]; then
-    export GLUON_PRIORITY=7
-fi
-
-# calculate number of threads
-if [ -z "$debug" ]; then
-    proc_num="$(($(grep -c '^processor\s' /proc/cpuinfo) + 1))"
-else
-    proc_num=1
-fi
-
-cd "$GLUON_DIR"
-export GLUON_BRANCH GLUON_RELEASE
-if ! $cont; then
-  make update ${debug:+V=s}
-fi
-
-for target in ar71xx-generic ar71xx-nand mpc85xx-generic x86-generic; do
-  env_target="$(echo "$target" | tr '-' '_')"
-  set +u
-  if eval "[ \"\$TARGET_${env_target}_DONE\" = 1 ]"; then
-    continue
-  fi
-  set -u
-  echo "Building target ${target}"
-  if $cont; then
-    cont=false
-  else
-    make clean GLUON_TARGET="$target" ${debug:+V=s}
-  fi
-  make -j${proc_num} GLUON_TARGET="$target" ${debug:+V=s}
-  echo "TARGET_${env_target}_DONE=1" >> "$statefile"
+for target in $GLUON_TARGETS; do
+    echo "Building target ${target}"
+    make clean GLUON_TARGET="$target" V=s
+    schedtool -B -e \
+        make --jobs=$(grep -c '^processor' /proc/cpuinfo) --output-sync=recurse \
+            GLUON_TARGET="$target" V=s
 done
-make manifest
-make manifest GLUON_BRANCH=testing GLUON_PRIORITY=0
-cd ..
 
-if [ -n "$KEYFILE" -a -r "$KEYFILE" ]; then
-  sed -i -e "/^BRANCH=testing/ a BRANCH=nightly" "${GLUON_DIR}/output/images/sysupgrade/testing.manifest"
-  "${GLUON_DIR}/contrib/sign.sh" "$KEYFILE" "${GLUON_DIR}/output/images/sysupgrade/testing.manifest"
+# generate manifests
+make manifest
+
+if [ -z "${GLUON_BRANCH:-}" ]; then
+    make manifest GLUON_BRANCH=testing GLUON_PRIORITY=0
+    # add BRANCH=nightly line below BRANCH=testing line
+    sed -i -e "/^BRANCH=testing/ a BRANCH=nightly" \
+        "${GLUON_DIR}/output/images/sysupgrade/testing.manifest"
 fi
 
-rm "$statefile"
+# sign testing/nightly manifest if key is present
+if [ -n "$KEYFILE" -a -r "$KEYFILE" ]; then
+    "${GLUON_DIR}/contrib/sign.sh" "$KEYFILE" \
+        "${GLUON_DIR}/output/images/sysupgrade/testing.manifest"
+fi

--- a/site.mk
+++ b/site.mk
@@ -33,6 +33,7 @@ GLUON_SITE_PACKAGES := \
 
 # Allow overriding the these variables from the command line
 GLUON_RELEASE ?= $(patsubst v%,%,$(shell git -C $(GLUON_SITEDIR) describe --tags --dirty=+))
+GLUON_BRANCH ?= stable
 GLUON_PRIORITY ?= 0
 GLUON_LANGS ?= en de
 GLUON_REGION ?= eu


### PR DESCRIPTION
Fixes #21.

Bitte testen und bewerten.
Eine evtl. erwähnenswerte Umstellung ist, dass *immer* mehrere Kerne genutzt werden, aber die Ausgabe korrekt sortiert wird. Das bedeutet, dass *beim Bauen* keine Ausgabe erfolgt, aber hinterher ggf. aufgetretene Fehler im richtigen Kontext stehen.