### PR TITLE
add dns forwarding

### DIFF
--- a/site.conf
+++ b/site.conf
@@ -62,7 +62,15 @@
 		ip6 = 'fd2f:5119:0f2c::127',
 		mac = '16:41:95:40:f7:dc',
 	},
-
+	dns = {
+		servers = {
+			'fd2f:5119:0f2c::1',
+			'fd2f:5119:0f2c::2',
+			'fd2f:5119:0f2c::3',
+			'fd2f:5119:0f2c::5',
+			'fd2f:5119:0f2c::6',
+		},
+	},
 	mesh_vpn = {
 		enabled = true,
 		mtu = 1280,


### PR DESCRIPTION
It would be nice to have always a running dns server with `node.ffhb.de` and `node.bremen.freifunk.net` running.
Also if it mean to forwards a lot of dns traffice my nodes.